### PR TITLE
edit__display_user-name

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,7 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    @group_member = @group.users.all
   end
 
   def create

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,7 +10,9 @@
         %ul.left-header__members
           Member：
           %li.member
-            -# グループメンバーを記載
+            - @group.group_users.each do |group_user|
+              = group_user.user.name
+
       .right-header
         .right-header__button
           Edit


### PR DESCRIPTION
# What
メッセージ画面上部に、
グループに所属している ユーザーの名前一覧を表示。

# Why

そのグループにどのメンバーが属しているのかをわかりやすくする為。